### PR TITLE
fix: latex error escapes on ampersands

### DIFF
--- a/checkermain.sh
+++ b/checkermain.sh
@@ -9,8 +9,8 @@
 FRMENV_FBTOKEN="${1:-${FRMENV_FBTOKEN}}"
 FRMENV_GIFTOKEN="${2:-${FRMENV_GIFTOKEN}}"
 
-format_noerr(){ printf '$\\fbox{\\color{#126329}\\textsf{\\normalsize  \\&#x2611; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;}
-format_err(){ printf '$\\fbox{\\color{#82061E}\\textsf{\\normalsize  \\&#x26A0; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;} 
+format_noerr(){ printf '$\\fbox{\\color{#126329}\\textsf{\\normalsize  &#x2611; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;}
+format_err(){ printf '$\\fbox{\\color{#82061E}\\textsf{\\normalsize  &#x26A0; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;} 
 format_table(){ printf '| \x60%s\x60 | %s |\n' "${1}" "${2}" ;}
 
 # Append Header


### PR DESCRIPTION
## Description

Please provide a brief description of your changes here.

## Checklist

Setupping Frames:
- [x] I Have disabled the `actions/init-banner`.
- [x] I Have changed the `frameiterator` file to `1`.
- [x] I Have setupped the `config.conf`.
- [x] I Have deleted the old frames and replaced the new frames.
- [x] I Have created a new Album and get the Album ID (optional).
- [x] I Have setupped the subtitles (optional).

---

`QA`: After you pushed the changes:
- [x] Have you enabled `actions/init-banner`?
- [x] I Have confimed it is working.
- [x] Is it visible to public?

## Checklist for Feats

Please review and complete these items before submitting your pull request:

- [x] I have tested my changes thoroughly and they work as expected.
- [x] I have included appropriate tests for any new features or bug fixes.
- [x] My code is well-formatted and complies with the ShellCheck standards.
- [x] I have updated the documentation (if applicable).
- [x] I have read and agree to the [code of conduct](CODE_OF_CONDUCT.md) and [contribution guidelines](CONTRIBUTING.md).
